### PR TITLE
Fix ruby utf8 byte sequence error

### DIFF
--- a/bin/check-hardware-fail.rb
+++ b/bin/check-hardware-fail.rb
@@ -30,12 +30,8 @@ require 'sensu-plugin/check/cli'
 
 class CheckHardwareFail < Sensu::Plugin::Check::CLI
   def run
-    errors = `dmesg`.lines.grep(/\[Hardware Error\]/)
-    # #YELLOW
-    unless errors.empty?
-      critical 'Hardware Error Detected'
-    end
-
+    errors = `dmesg`.lines.select { |l| l['[Hardware Error]'] }
+    critical 'Hardware Error Detected' if errors.any?
     ok 'Hardware OK'
   end
 end


### PR DESCRIPTION
`Enumerable.grep` throw's encoding exception when kernel drivers logs binary data to kernel ring buffer.  

For example:
```
test ~$ dmesg
... 
ACPI: SRAT 00000000bddcc7c0 005C0 (v01 HP     Proliant 00000001   <D2>? 0000162E)
ACPI: FFFF 00000000bddccd80 00176 (v01 HP     ProLiant 00000001   <D2>? 0000162E)
ACPI: BERT 00000000bddccf00 00030 (v01 HP     ProLiant 00000001   <D2>? 0000162E)
ACPI: HEST 00000000bddccf40 000BC (v01 HP     ProLiant 00000001   <D2>? 0000162E)
...
```

Error:
```
Check failed to run: invalid byte sequence in UTF-8, 
"/etc/sensu/plugins/check-hardware-fail.rb:33:in `==='", 
"/etc/sensu/plugins/check-hardware-fail.rb:33:in `each'", 
"/etc/sensu/plugins/check-hardware-fail.rb:33:in `grep'", 
"/etc/sensu/plugins/check-hardware-fail.rb:33:in `run'"
```