### PR TITLE
return the entire line from a match and not the literal source pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [1.1.1] - 2017-11-01
-### Changed
-- Return the actual and entire query line match if found
-
 ## [1.1.0] - 2017-07-17
 ### Added
 - Option to limit the number of lines to be parsed from the dmesg output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.1] - 2017-11-01
+### Changed
+- Return the actual and entire query line match if found
+
 ## [1.1.0] - 2017-07-17
 ### Added
 - Option to limit the number of lines to be parsed from the dmesg output

--- a/bin/check-hardware-fail.rb
+++ b/bin/check-hardware-fail.rb
@@ -41,7 +41,7 @@ class CheckHardwareFail < Sensu::Plugin::Check::CLI
          short: '-q QUERY',
          long: '--query QUERY',
          default: 'Hardware Error',
-         description: 'What to look for in the output of dmesg'
+         description: 'What pattern to look for in the output of dmesg (regex or literal)'
 
   option :invert,
          long: '--invert',
@@ -52,12 +52,12 @@ class CheckHardwareFail < Sensu::Plugin::Check::CLI
   def run
     cmd = config[:invert] ? 'head' : 'tail'
     errors = if config[:lines] == 0
-               `dmesg`.lines.select { |l| l[/#{config[:query]}/] }
+               output = `dmesg`.lines.select { |l| l[/#{config[:query]}/] }
              else
-               `dmesg | #{cmd} -n #{config[:lines]}`.lines.select { |l| l[/#{config[:query]}/] }
+               output = `dmesg | #{cmd} -n #{config[:lines]}`.lines.select { |l| l[/#{config[:query]}/] }
              end
     unknown 'Command execution failed!' unless $CHILD_STATUS.success?
-    critical "Problem Detected: #{config[:query]}" if errors.any?
+    critical "Problem Detected: #{output[0]}" if errors.any?
     ok 'OK'
   end
 end

--- a/bin/check-hardware-fail.rb
+++ b/bin/check-hardware-fail.rb
@@ -51,13 +51,13 @@ class CheckHardwareFail < Sensu::Plugin::Check::CLI
 
   def run
     cmd = config[:invert] ? 'head' : 'tail'
-    errors = if config[:lines] == 0
-               output = `dmesg`.lines.select { |l| l[/#{config[:query]}/] }
+    output = if config[:lines].zero?
+               `dmesg`.lines.select { |l| l[/#{config[:query]}/] }
              else
-               output = `dmesg | #{cmd} -n #{config[:lines]}`.lines.select { |l| l[/#{config[:query]}/] }
+               `dmesg | #{cmd} -n #{config[:lines]}`.lines.select { |l| l[/#{config[:query]}/] }
              end
     unknown 'Command execution failed!' unless $CHILD_STATUS.success?
-    critical "Problem Detected: #{output[0]}" if errors.any?
+    critical "Problem Detected: #{output[0]}" if output.any?
     ok 'OK'
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
return the entire line from a match and not the literal source pattern
#### Known Compatablity Issues

